### PR TITLE
Update onelistforallmicro.txt

### DIFF
--- a/onelistforallmicro.txt
+++ b/onelistforallmicro.txt
@@ -37715,3 +37715,4 @@ admincall
 godep-save.sh
 .coafile
 asterisk@home
+birt


### PR DESCRIPTION
Added the word birt. This directory is related with the software BIRT Viewer, which has different vulns, some of them RCEs.

https://www.synacktiv.com/sites/default/files/2023-03/Synacktiv-BIRTViewer-CVE-2023-0100_1.pdf